### PR TITLE
feat: use embedded_hal_async & remove async features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,15 @@ authors = ["qiuchengxuan <qiuchengxuan@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/qiuchengxuan/async-sdmmc"
 
+[lib]
+name = "sdmmc"
+
 [dependencies]
 async-trait = { version = "0.1", optional = true }
 bitfield = "0.13"
 deasync = "0.1"
 embedded-hal = "0.2"
+embedded-hal-async = { version = "0.2.0-alpha.0" }
 fugit = { version = "0.3", optional = true }
 gpio = { version = "0.4", optional = true }
 log = "0.4"
@@ -23,10 +27,8 @@ void = { version = "1.0", optional = true }
 hex-literal = "0.3"
 
 [features]
-async = []
+default = []
 std = []
 linux-spi = ["std", "gpio", "void", "spidev"]
 log-max-level-off = ["log/max_level_off", "log/release_max_level_off"]
 
-[lib]
-name = "sdmmc"

--- a/README.md
+++ b/README.md
@@ -31,14 +31,6 @@ Ok(())
 Features
 --------
 
-* **async**
-
-  Enable async support
-
-* **async-trait**
-
-  Use async-trait, otherwise nightly unstable `async_fn_in_trait` feature is enabled
-
 * **std**
 
   Use std library

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-stable
+nightly

--- a/sdmmc-test/Cargo.toml
+++ b/sdmmc-test/Cargo.toml
@@ -22,7 +22,6 @@ size = "0.4"
 spidev = "0.5"
 
 [features]
-async = ["async-embedded-sdmmc/async"]
 
 [[bin]]
 name = "sdmmc"

--- a/src/bus/linux.rs
+++ b/src/bus/linux.rs
@@ -1,26 +1,102 @@
-use std::{io, time};
+use core::future::Future;
+use std::{
+    io::{self, ErrorKind as IoKind, Read, Write},
+    time,
+};
 
 use gpio::{sysfs::SysFsGpioOutput, GpioOut};
 use spidev::{SpiModeFlags, Spidev, SpidevOptions, SpidevTransfer};
 
+use embedded_hal_async::spi::{
+    Error as SpiError, ErrorKind, ErrorType, SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite,
+    SpiDevice,
+};
+
 use crate::bus::spi;
+
+#[derive(Debug)]
+pub struct Error(std::io::Error);
+
+impl SpiError for Error {
+    fn kind(&self) -> ErrorKind {
+        match self.0.kind() {
+            IoKind::OutOfMemory => ErrorKind::Overrun,
+            IoKind::Other => ErrorKind::Other,
+            _ => ErrorKind::Other,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(io_error: std::io::Error) -> Self {
+        Self(io_error)
+    }
+}
 
 pub struct SPI(pub Spidev);
 
-#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
-#[cfg_attr(not(feature = "async"), deasync::deasync)]
-impl spi::Transfer for SPI {
-    type Error = io::Error;
+impl ErrorType for SPI {
+    type Error = Error;
+}
+impl SpiBusRead for SPI {
+    async fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(self.0.read(words).map(|_| ())?)
+    }
+}
 
-    async fn transfer(&mut self, tx: &[u8], rx: &mut [u8]) -> io::Result<()> {
-        let mut buf = Vec::with_capacity(std::cmp::max(tx.len(), rx.len()));
-        if tx.len() > 0 {
-            buf.resize(tx.len(), 0);
-            self.0.transfer(&mut SpidevTransfer::read_write(tx, &mut buf))
+impl SpiBusWrite for SPI {
+    async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        Ok(self.0.write(words).map(|_| ())?)
+    }
+}
+
+impl SpiBusFlush for SPI {
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(self.0.flush()?)
+    }
+}
+
+impl SpiBus for SPI {
+    async fn transfer<'a>(
+        &'a mut self,
+        read: &'a mut [u8],
+        write: &'a [u8],
+    ) -> Result<(), Self::Error> {
+        let mut buf = Vec::with_capacity(std::cmp::max(read.len(), write.len()));
+        if write.len() > 0 {
+            buf.resize(write.len(), 0);
+            Ok(self.0.transfer(&mut SpidevTransfer::read_write(write, &mut buf))?)
         } else {
-            buf.resize(rx.len(), 0xFF);
-            self.0.transfer(&mut SpidevTransfer::read_write(&buf, rx))
+            buf.resize(read.len(), 0xFF);
+            Ok(self.0.transfer(&mut SpidevTransfer::read_write(&buf, read))?)
         }
+    }
+
+    async fn transfer_in_place<'a>(&'a mut self, words: &'a mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+unsafe impl SpiDevice for SPI {
+    type Bus = Self;
+
+    async fn transaction<R, F, Fut>(&mut self, f: F) -> Result<R, Self::Error>
+    where
+        F: FnOnce(*mut Self::Bus) -> Fut,
+        Fut: Future<Output = Result<R, <Self::Bus as ErrorType>::Error>>,
+    {
+        f(self).await
+        // let bus = unsafe { &mut *self };
+
+        // let result = async move {
+        //     let result = f(bus);
+        //     let bus = bus; // Ensure that the bus reference was not moved out of the closure
+        //     let _ = bus; // Silence the "unused variable" warning from previous line
+        //     result
+        // }
+        // .await;
+
+        // result.await
     }
 }
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -2,9 +2,6 @@
 pub mod linux;
 pub mod spi;
 
-#[cfg(feature = "async-trait")]
-use alloc::boxed::Box;
-
 use crate::sd::{registers::CSD, response::R1Status, transfer, BLOCK_SIZE};
 
 #[derive(Debug)]
@@ -17,7 +14,7 @@ pub enum Error<BUS> {
     NotIdle,
     /// Command related error
     Command(R1Status),
-    /// Tranfer error
+    /// Transfer error
     Transfer(transfer::TokenError),
     /// No respond within expected duration
     Timeout,
@@ -37,8 +34,6 @@ pub trait Bus {
     fn after(&mut self) -> Result<(), Error<Self::Error>>;
 }
 
-#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
-#[cfg_attr(not(feature = "async"), deasync::deasync)]
 pub trait Read {
     type Error;
     async fn read_csd(&mut self) -> Result<CSD, Error<Self::Error>>;
@@ -47,10 +42,9 @@ pub trait Read {
         B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]> + Send;
 }
 
-#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
-#[cfg_attr(not(feature = "async"), deasync::deasync)]
 pub trait Write {
     type Error;
+
     async fn write<'a, B>(&mut self, block: u32, blocks: B) -> Result<(), Error<Self::Error>>
     where
         B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]> + Send;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,39 +1,15 @@
-#[cfg(feature = "async")]
-use core::future;
-
-#[cfg(not(feature = "async"))]
-use embedded_hal::blocking::delay::DelayMs;
-
-#[cfg(feature = "async")]
 pub trait Delay<UXX> {
-    type Future: future::Future<Output = ()>;
-    fn delay_ms(&mut self, duration: UXX) -> Self::Future;
+    async fn delay_ms(&mut self, duration: UXX) -> ();
 }
-
-#[cfg(not(feature = "async"))]
-pub trait Delay<UXX>: DelayMs<UXX> {}
-
-#[cfg(not(feature = "async"))]
-impl<UXX, T: DelayMs<UXX>> Delay<UXX> for T {}
 
 #[cfg(feature = "std")]
 pub mod std {
     pub struct Delay;
 
-    #[cfg(feature = "async")]
     impl<UXX: Into<u64>> super::Delay<UXX> for Delay {
-        type Future = std::future::Ready<()>;
-
-        fn delay_ms(&mut self, ms: UXX) -> Self::Future {
-            std::thread::sleep(std::time::Duration::from_millis(ms.into()));
-            std::future::ready(())
-        }
-    }
-
-    #[cfg(not(feature = "async"))]
-    impl<UXX: Into<u64>> embedded_hal::blocking::delay::DelayMs<UXX> for Delay {
-        fn delay_ms(&mut self, ms: UXX) {
+        async fn delay_ms(&mut self, ms: UXX) {
             std::thread::sleep(std::time::Duration::from_millis(ms.into()));
         }
     }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,21 @@
-#![doc = include_str!("../README.md")]
+// #![doc = include_str!("../README.md")]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
-#![cfg_attr(all(feature = "async", not(feature = "async-trait")), feature(async_fn_in_trait))]
+
+#![cfg(nightly)]
+
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
 
 #[cfg(feature = "async-trait")]
 extern crate alloc;
-#[macro_use]
-extern crate log;
-#[cfg(feature = "spidev")]
-extern crate spidev;
 
 pub mod bus;
 pub mod delay;
 mod sd;
 
-use bus::Error;
 pub use sd::registers::NumBlocks;
+
+use bus::Error;
 use sd::{registers::CSD, BLOCK_SIZE};
 
 pub struct SD<BUS> {
@@ -25,7 +26,6 @@ pub struct SD<BUS> {
 
 type LBA = u32;
 
-#[cfg_attr(not(feature = "async"), deasync::deasync)]
 impl<E, BUS> SD<BUS>
 where
     BUS: bus::Read<Error = E> + bus::Write<Error = E> + bus::Bus<Error = E>,


### PR DESCRIPTION
A few outstanding issues:
- Even if we add a feature to enable `async` that could complicate the code for the crate as we not only need to `deasync` all traits, methods and but also remove the `.await` points with `cfg` or `cfg_if` which I'm not sure if it's possible and how well will play with the API and maintainability
- Even though I will try to test the crate on an embedded system, I would like to see an example of how to setup an SD card and some docs surrounding it, as it's not clear to me how to set it up, as I'm not that familiar with the SD card standard and protocol

Until there is a common word like the proposed `?async` (I believe it was called) which marks methods as usable as either async or not the best course of action which I've seen crate API implement is duplicating the interface with async.