### PR TITLE
refactor: Remove unnecessary Send constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-embedded-sdmmc"
 description = "Embedded sdmmc driver with async support"
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["qiuchengxuan <qiuchengxuan@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/qiuchengxuan/async-sdmmc"

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -40,7 +40,7 @@ pub trait Read {
     #[cfg(not(feature = "async"))]
     fn read<'a, B>(&mut self, block: u32, blocks: B) -> Result<(), Error<Self::Error>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]> + Send;
+        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]>;
 
     #[cfg(feature = "async")]
     fn read_csd(&mut self) -> impl Future<Output = Result<CSD, Error<Self::Error>>>;
@@ -51,7 +51,7 @@ pub trait Read {
         blocks: B,
     ) -> impl Future<Output = Result<(), Error<Self::Error>>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]> + Send;
+        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]>;
 }
 
 pub trait Write {
@@ -59,7 +59,7 @@ pub trait Write {
     #[cfg(not(feature = "async"))]
     fn write<'a, B>(&mut self, block: u32, blocks: B) -> Result<(), Error<Self::Error>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]> + Send;
+        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]>;
     #[cfg(feature = "async")]
     fn write<'a, B>(
         &mut self,
@@ -67,5 +67,5 @@ pub trait Write {
         blocks: B,
     ) -> impl Future<Output = Result<(), Error<Self::Error>>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]> + Send;
+        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]>;
 }

--- a/src/bus/spi/mod.rs
+++ b/src/bus/spi/mod.rs
@@ -17,9 +17,9 @@ pub use bus::{BUSError, Bus, Transfer};
 
 impl<E, F, SPI, CS, C, I> Bus<SPI, CS, C>
 where
-    SPI: Transfer<Error = E> + Send,
-    CS: OutputPin<Error = F> + Send,
-    C: Clock<Instant = I> + Send,
+    SPI: Transfer<Error = E>,
+    CS: OutputPin<Error = F>,
+    C: Clock<Instant = I>,
     I: Instant,
 {
     #[cfg_attr(not(feature = "async"), deasync::deasync)]

--- a/src/bus/spi/read.rs
+++ b/src/bus/spi/read.rs
@@ -18,9 +18,9 @@ use super::bus::{BUSError, Bus, Error, Transfer};
 
 impl<E, F, SPI, CS, C, I> Bus<SPI, CS, C>
 where
-    SPI: Transfer<Error = E> + Send,
-    CS: OutputPin<Error = F> + Send,
-    C: Clock<Instant = I> + Send,
+    SPI: Transfer<Error = E>,
+    CS: OutputPin<Error = F>,
+    C: Clock<Instant = I>,
     I: Instant,
 {
     #[cfg_attr(not(feature = "async"), deasync::deasync)]
@@ -53,9 +53,9 @@ where
 #[cfg_attr(not(feature = "async"), deasync::deasync)]
 impl<E, F, SPI, CS, C, I> Read for Bus<SPI, CS, C>
 where
-    SPI: Transfer<Error = E> + Send,
-    CS: OutputPin<Error = F> + Send,
-    C: Clock<Instant = I> + Send,
+    SPI: Transfer<Error = E>,
+    CS: OutputPin<Error = F>,
+    C: Clock<Instant = I>,
     I: Instant,
 {
     type Error = Error<E, F>;
@@ -73,7 +73,7 @@ where
 
     async fn read<'a, B>(&mut self, address: u32, blocks: B) -> Result<(), BUSError<E, F>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]> + Send,
+        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]>,
     {
         self.tx(&[0xFF; 5]).await?;
         self.select()?;

--- a/src/bus/spi/write.rs
+++ b/src/bus/spi/write.rs
@@ -18,16 +18,16 @@ use super::bus::{BUSError, Bus, Error, Transfer};
 #[cfg_attr(not(feature = "async"), deasync::deasync)]
 impl<E, F, SPI, CS, C, I> Write for Bus<SPI, CS, C>
 where
-    SPI: Transfer<Error = E> + Send,
-    CS: OutputPin<Error = F> + Send,
-    C: Clock<Instant = I> + Send,
+    SPI: Transfer<Error = E>,
+    CS: OutputPin<Error = F>,
+    C: Clock<Instant = I>,
     I: Instant,
 {
     type Error = Error<E, F>;
 
     async fn write<'a, B>(&mut self, address: u32, blocks: B) -> Result<(), BUSError<E, F>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]> + Send,
+        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]>,
     {
         self.tx(&[0xFF; 5]).await?;
         self.select()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ where
 
     pub async fn read<'a, B>(&mut self, address: LBA, blocks: B) -> Result<(), Error<E>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]> + Send,
+        B: core::iter::ExactSizeIterator<Item = &'a mut [u8; BLOCK_SIZE]>,
     {
         if blocks.len() == 0 {
             return Ok(());
@@ -69,7 +69,7 @@ where
 
     pub async fn write<'a, B>(&mut self, address: LBA, blocks: B) -> Result<(), Error<E>>
     where
-        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]> + Send,
+        B: core::iter::ExactSizeIterator<Item = &'a [u8; BLOCK_SIZE]>,
     {
         if blocks.len() == 0 {
             return Ok(());


### PR DESCRIPTION
After removal of async-trait, Send constraint is no longer necessary

Fix: #5 